### PR TITLE
Node was failing on semver and lodash requires

### DIFF
--- a/tasks/grunt-crosswalk.js
+++ b/tasks/grunt-crosswalk.js
@@ -2,8 +2,6 @@ module.exports = function (grunt) {
   var path = require('path');
   var which = require('which');
   var fs = require('fs');
-  var semver = require('semver');
-  var _ = require('lodash');
 
   var Api = require('crosswalk-apk-generator');
 


### PR DESCRIPTION
semver and lodash are no longer required by grunt-crosswalk.js and fail Node.